### PR TITLE
German date time period parser configuration fix

### DIFF
--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
@@ -20,6 +20,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeRe
 import com.microsoft.recognizers.text.datetime.resources.GermanDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodParserConfiguration {
@@ -328,11 +329,18 @@ public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfigur
 
         String trimmedText = text.trim().toLowerCase();
 
+        Pattern regex = Pattern.compile(GermanDateTime.PreviousPrefixRegex);
+        Matcher regexMatcher = regex.matcher(trimmedText);
+
         int swift = 0;
-        if (trimmedText.startsWith("next")) {
-            swift = 1;
-        } else if (trimmedText.startsWith("last")) {
+        if (regexMatcher.find()) {
             swift = -1;
+        } else {
+            regex = Pattern.compile(GermanDateTime.NextPrefixRegex);
+            regexMatcher = regex.matcher(text);
+            if (regexMatcher.find()) {
+                swift = 1;
+            }
         }
 
         return swift;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
@@ -20,7 +20,6 @@ import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeRe
 import com.microsoft.recognizers.text.datetime.resources.GermanDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodParserConfiguration {
@@ -329,18 +328,11 @@ public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfigur
 
         String trimmedText = text.trim().toLowerCase();
 
-        Pattern regex = Pattern.compile(GermanDateTime.PreviousPrefixRegex);
-        Matcher regexMatcher = regex.matcher(trimmedText);
-
         int swift = 0;
-        if (regexMatcher.find()) {
+        if (trimmedText.startsWith("next")) {
+            swift = 1;
+        } else if (trimmedText.startsWith("last")) {
             swift = -1;
-        } else {
-            regex = Pattern.compile(GermanDateTime.NextPrefixRegex);
-            regexMatcher = regex.matcher(text);
-            if (regexMatcher.find()) {
-                swift = 1;
-            }
         }
 
         return swift;

--- a/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
+++ b/Java/libraries/recognizers-text-date-time/src/main/java/com/microsoft/recognizers/text/datetime/german/parsers/GermanDateTimePeriodParserConfiguration.java
@@ -20,6 +20,7 @@ import com.microsoft.recognizers.text.datetime.parsers.config.MatchedTimeRangeRe
 import com.microsoft.recognizers.text.datetime.resources.GermanDateTime;
 import com.microsoft.recognizers.text.utilities.RegExpUtility;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfiguration implements IDateTimePeriodParserConfiguration {
@@ -67,7 +68,7 @@ public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfigur
     public static final Pattern AfternoonStartEndRegex = RegExpUtility.getSafeRegExp(GermanDateTime.AfternoonStartEndRegex);
     public static final Pattern EveningStartEndRegex = RegExpUtility.getSafeRegExp(GermanDateTime.EveningStartEndRegex);
     public static final Pattern NightStartEndRegex = RegExpUtility.getSafeRegExp(GermanDateTime.NightStartEndRegex);
-    
+
     public GermanDateTimePeriodParserConfiguration(ICommonDateTimeParserConfiguration config) {
 
         super(config.getOptions());
@@ -328,11 +329,18 @@ public class GermanDateTimePeriodParserConfiguration extends BaseOptionsConfigur
 
         String trimmedText = text.trim().toLowerCase();
 
+        Pattern regex = Pattern.compile(GermanDateTime.PreviousPrefixRegex);
+        Matcher regexMatcher = regex.matcher(trimmedText);
+
         int swift = 0;
-        if (trimmedText.startsWith("next")) {
-            swift = 1;
-        } else if (trimmedText.startsWith("last")) {
+        if (regexMatcher.find()) {
             swift = -1;
+        } else {
+            regex = Pattern.compile(GermanDateTime.NextPrefixRegex);
+            regexMatcher = regex.matcher(text);
+            if (regexMatcher.find()) {
+                swift = 1;
+            }
         }
 
         return swift;


### PR DESCRIPTION
Used the existing GermanDateTime regex's (following the spanish model).  sorry about the messy commits...